### PR TITLE
Fix bug in extrapolation with weighted averaging

### DIFF
--- a/scripts/cp2k-extrapolate.py
+++ b/scripts/cp2k-extrapolate.py
@@ -91,9 +91,11 @@ else:
             args.height, verbose=True)
     np.savetxt(hartree_planefile, hartree_plane)
 
-hartree_avg = np.mean(hartree_plane) / eV2Ha
-hartree_min = np.min(hartree_plane) / eV2Ha
-hartree_max = np.max(hartree_plane) / eV2Ha
+hartree_plane /= eV2Ha
+
+hartree_avg = np.mean(hartree_plane)
+hartree_min = np.min(hartree_plane)
+hartree_max = np.max(hartree_plane)
 print("Hartree potential on extrapolation surface:")
 print("   min {:+.4f} eV, max {:+4f} eV, avg {:+.4f} eV" \
         .format(hartree_min, hartree_max, hartree_avg))
@@ -138,8 +140,8 @@ for fname in args.cubes:
         weighted_hartree = hartree_plane * density_plane
         weighted_hartree_avg = np.sum(weighted_hartree)
         print("Weighted average of Hartree potential: {:+.4f} eV" \
-            .format(weighted_hartree_avg/eV2Ha))
-        hartree = weighted_hartree_avg/eV2Ha
+            .format(weighted_hartree_avg))
+        hartree = weighted_hartree_avg
 
     # Note: Working in Hartree atomic units here
     E = (cube.energy - hartree) * eV2Ha * np.dot(cube.dz, cube.dz) / a02A**2
@@ -195,4 +197,3 @@ and therefore cannot be extrapolated."""
 
 print("")
 print("Job done.")
-    

--- a/scripts/cp2k-extrapolate.py
+++ b/scripts/cp2k-extrapolate.py
@@ -139,7 +139,7 @@ for fname in args.cubes:
         weighted_hartree_avg = np.sum(weighted_hartree)
         print("Weighted average of Hartree potential: {:+.4f} eV" \
             .format(weighted_hartree_avg/eV2Ha))
-        hartree = weighted_hartree_avg
+        hartree = weighted_hartree_avg/eV2Ha
 
     # Note: Working in Hartree atomic units here
     E = (cube.energy - hartree) * eV2Ha * np.dot(cube.dz, cube.dz) / a02A**2


### PR DESCRIPTION
If you take a look at line 145
` E = (cube.energy - hartree) * eV2Ha * np.dot(cube.dz, cube.dz) / a02A**2`,
which assumes that hartree is in eV.
When using weighted_avg, it however is updated with a value in Hartree units.
